### PR TITLE
change base width

### DIFF
--- a/ScaleBarView.swift
+++ b/ScaleBarView.swift
@@ -77,7 +77,7 @@ class ScaleBarView: UIView {
         let scaleDistance = scaleWidth/screenWidth * screenDistance
         let roundedDistance = scaleDistance.roundAsDistance()
         let scaleRatio = CGFloat(roundedDistance) / screenDistance
-        let scaleBarWidth =  scaleWidth * scaleRatio
+        let scaleBarWidth =  screenWidth * scaleRatio
         return CGFloat(scaleBarWidth)
     }
     


### PR DESCRIPTION
@yoman07 

Hi, 

Thank you for your source code.

I think that I found a bug this line.

https://github.com/yoman07/ios-google-maps-scale-bar/blob/bc3eab70a9ea80e5df9d8187ef7cd2f508f938a0/ScaleBarView.swift#L80

If scaleBarView width equals to `screenWidth` then this code is right, but if scaleBarView width does not equal to `screenWidth` then the bar length is wrong.

I changed `screenWidth` to `screenWidth`, and it looks good.

regards, 